### PR TITLE
add "cursor: pointer" to allow click events on iOS

### DIFF
--- a/src/components/Listing/styles.module.css
+++ b/src/components/Listing/styles.module.css
@@ -13,6 +13,7 @@
   border-bottom: 1px solid #eeeeee;
   padding: 10px;
   text-decoration: none;
+  cursor: pointer;
 
   h1 {
     flex: 2;


### PR DESCRIPTION
- iOS has a quirky bug where it requires a button element or cursor: pointer added to an element to accept click events.