### PR TITLE
isDev config now shared with isTest

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const modules = join(root, 'node_modules');
 const dest    = join(root, 'dist');
 
 var config = getConfig({
-  isDev: isDev,
+  isDev: isDev || isTest,
   in: join(src, 'app.js'),
   out: dest,
   html: function (context) {


### PR DESCRIPTION
I have fixed a bug mentioned in this issue [here](https://github.com/fullstackreact/react-yelp-clone/issues/12) which results in the tests failing with react 15.2.1 or more recent.

The problem is that as of react 15.2.1 react test-utils will no longer run in prod mode, and the webpack config has isTest not sharing all isDev configuration. I have made a fix so that now isTest will share all isDev config. You can see on line _21_ of _webpack.config.js_ on the branch **react15_2_1_test_compat**

Tests will now pass successfully with react15.2.1.

I think it would be useful to pull this into the repository, and also maybe the tutorial should be updated to reflect this change

best wishes

joegrundman
